### PR TITLE
Better build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ platformio.sublime*
 platformio.pro*
 tests
 research
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ platformio.sublime*
 platformio.pro*
 tests
 research
+.pio
 .vscode

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The ```git clone --recursive``` above not only cloned the MavESP8266 repository 
 
 ### Wiring it up
 
-User level (as well as wiring) instructions can be found here: https://pixhawk.org/peripherals/8266
+User level (as well as wiring) instructions can be found [here for px4](https://docs.px4.io/en/telemetry/esp8266_wifi_module.html) and [here for ArduPilot](http://ardupilot.org/copter/docs/common-esp8266-telemetry.html)
 
 * Resetting to Defaults: In case you change the parameters and get locked out of the module, all the parameters can be reset by bringing the GPIO02 pin low (Connect GPIO02 pin to GND pin). 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -5,38 +5,41 @@
 # http://docs.platformio.org/en/latest/projectconf.html
 #
 
-# A sign `#` at the beginning of the line indicates a comment
-# Comment lines are ignored.
-
-# Simple and base environment
-# [env:mybaseenv]
-# platform = %INSTALLED_PLATFORM_NAME_HERE%
-# framework =
-# board =
-#
-# Automatic targets - enable auto-uploading
-# targets = upload
-
 # The upload speed below (921600) has worked fine for all modules I tested. If you have upload issues,
 # try reducing to 115200.
 
+# Set mavesp version
+
 [version]
-build_flags = !echo "-DPIO_SRC_REV="$(git rev-parse HEAD) "-DPIO_BUILD_DATE="$(date +%%Y-%%m-%%d) "-DPIO_BUILD_TIME="$(date +%%H:%%M:%%S)
+major = 1
+minor = 2
+build = 2
+
+# Generate version string (e.g "1.2.2") and flags
+
+[version_env]
+version_string = ${version.major}.${version.minor}.${version.build}
+version_flags = "-DMAVESP8266_VERSION_MINOR="${version.minor} "-DMAVESP8266_VERSION_MAJOR="${version.major} "-DMAVESP8266_VERSION_BUILD="${version.build} "-DVERSION_STRING="${version_env.version_string}
+
+# General settings
+# - Set platform and framework
+# - Generate revision, date and time flags
+# - Run prebuild script to set firmware name
+
+[env]
+platform = espressif8266@1.8.0
+framework = arduino
+build_flags = !echo "-DPIO_SRC_REV="$(git rev-parse HEAD) "-DPIO_BUILD_DATE="$(date +%%Y-%%m-%%d) "-DPIO_BUILD_TIME="$(date +%%H:%%M:%%S) ${version_env.version_flags}
+extra_scripts = pre:platformio_prebuild.py
+
+# Platform specific settings
 
 [env:esp12e]
-platform = espressif8266@1.8.0
-framework = arduino
 board = esp12e
-build_flags = ${version.build_flags} -Wl,-Tesp8266.flash.4m.ld
+build_flags = ${env.build_flags} -Wl,-Tesp8266.flash.4m.ld
 
 [env:esp01_1m]
-platform = espressif8266@1.8.0
-framework = arduino
 board = esp01_1m
-build_flags = ${version.build_flags}
 
 [env:esp01]
-platform = espressif8266@1.8.0
-framework = arduino
 board = esp01
-build_flags = ${version.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,19 +24,19 @@
 build_flags = !echo "-DPIO_SRC_REV="$(git rev-parse HEAD) "-DPIO_BUILD_DATE="$(date +%%Y-%%m-%%d) "-DPIO_BUILD_TIME="$(date +%%H:%%M:%%S)
 
 [env:esp12e]
-platform = espressif8266
+platform = espressif8266@1.8.0
 framework = arduino
 board = esp12e
 build_flags = ${version.build_flags} -Wl,-Tesp8266.flash.4m.ld
 
 [env:esp01_1m]
-platform = espressif8266
+platform = espressif8266@1.8.0
 framework = arduino
 board = esp01_1m
 build_flags = ${version.build_flags}
 
 [env:esp01]
-platform = espressif8266
+platform = espressif8266@1.8.0
 framework = arduino
 board = esp01
 build_flags = ${version.build_flags}

--- a/platformio_prebuild.py
+++ b/platformio_prebuild.py
@@ -1,0 +1,14 @@
+Import("env")
+
+# retrieve build flags
+my_flags = env.ParseFlags(env['BUILD_FLAGS'])
+defines = {k: v for (k, v) in my_flags.get("CPPDEFINES")}
+
+version_string = defines.get("VERSION_STRING")  # e.g. "1.2.2"
+board_name = env["BOARD"]  # e.g. "esp01m"
+
+# replace dots in version if linker can't find the path
+#version_string = version_string.replace(".","_")
+
+# set board and version in firmware name
+env.Replace(PROGNAME="mavesp-{}-{}".format(board_name, version_string))

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -62,10 +62,7 @@ class MavESP8266GCS;
 
 #define HEARTBEAT_TIMEOUT           10 * 1000
 
-//-- TODO: This needs to come from the build system
-#define MAVESP8266_VERSION_MAJOR    1
-#define MAVESP8266_VERSION_MINOR    2
-#define MAVESP8266_VERSION_BUILD    2
+//-- The version is set from the build system (major, minor and build)
 #define MAVESP8266_VERSION          ((MAVESP8266_VERSION_MAJOR << 24) & 0xFF00000) | ((MAVESP8266_VERSION_MINOR << 16) & 0x00FF0000) | (MAVESP8266_VERSION_BUILD & 0xFFFF)
 
 //-- Debug sent out to Serial1 (GPIO02), which is TX only (no RX).

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -35,13 +35,13 @@
  * @author Gus Grubba <mavlink@grubba.com>
  */
 
+#include <ESP8266WebServer.h>
+
 #include "mavesp8266.h"
 #include "mavesp8266_httpd.h"
 #include "mavesp8266_parameters.h"
 #include "mavesp8266_gcs.h"
 #include "mavesp8266_vehicle.h"
-
-#include <ESP8266WebServer.h>
 
 const char PROGMEM kTEXTPLAIN[]  = "text/plain";
 const char PROGMEM kTEXTHTML[]   = "text/html";


### PR DESCRIPTION
+ Build fixed on newer versions of platformio
+ Version numbers are set in platformio.ini
+ Firmware file is renamed `mavesp-{board}-{version}` e.g. `mavesp-esp12e-1.2.2.bin`
